### PR TITLE
updates sc/syllabus

### DIFF
--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-6">
-    <h3 id="syllabus-shell">The Unix Shell</h3>
+    <h3 id="syllabus-shell">La Terminal de Unix</h3>
     <ul>
         <li>Archivos y directorios</li>
         <li>History and tab completion</li>
@@ -10,6 +10,8 @@
         <li>Encontrar cosas</li>
       <li><a href="{{site.swc_pages}}/shell-novice/reference/">Referencia...</a></li>
     </ul>
+  
+  <!--  
   </div>
   <div class="col-md-6">
       <h3 id="syllabus-python">Programación en Python</h3>
@@ -24,6 +26,8 @@
       <li><a href="{{site.swc_pages}}/python-novice-inflammation/reference/">Referencia...</a></li>
     </ul>
   </div>
+    -->
+  
   <!--
   <div class="col-md-6">
     <h3 id="syllabus-r">Programming in R</h3>
@@ -37,6 +41,24 @@
     </ul>
   </div>
   -->
+  
+
+  <div class="col-md-6">
+    <h3 id="syllabus-r">https://swcarpentry.github.io/r-novice-gapminder-es/</h3>
+    <ul>
+    	<li>Gestión de proyectos con RStudio</li>
+      <li>Explorando Data Frames</li>
+      <li>Creando gráficas con <code>ggplot</code></li>
+      <li>Creando y usando funciones</li>
+      <li>Manipulando dataframes con <code>dplyr</code> y <code>plyr</code></li>
+      <li>Escribiendo buen software</li>
+      <li><a href="{{site.swc_pages}}/r-novice-inflammation/reference/">Reference...</a></li>
+    </ul>
+  </div>
+
+
+ 
+  
   <!--
   <div class="col-md-6">
     <h3 id="syllabus-matlab">Programming in MATLAB</h3>
@@ -67,6 +89,7 @@
       <li><a href="{{site.swc_pages}}/git-novice/reference/">Referencia...</a></li>
     </ul>
   </div>
+  
   <!--
   <div class="col-md-6">
     <h3 id="syllabus-sql">Managing Data with SQL</h3>
@@ -83,6 +106,8 @@
     </ul>
   </div>
    -->
+   
+   <!-- 
   <div class="col-md-6">
       <h3 id="syllabus-r">Open Refine</h3>
       <ul>
@@ -94,3 +119,4 @@
     </ul>
   </div>
 </div>
+-->

--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -76,7 +76,7 @@
 
 <div class="row">
   <div class="col-md-6">
-      <h3 id="syllabus-git">Control de versiones con Git</h3>
+      <h3 id="syllabus-git">Control de Versiones con Git</h3>
       <ul>
           <li>Creando un repositorio</li>
           <li>Grabación de cambios en los archivos: <code>add</code>, <code>commit</code>, ...</li>

--- a/_includes/sc/syllabus.html
+++ b/_includes/sc/syllabus.html
@@ -44,7 +44,7 @@
   
 
   <div class="col-md-6">
-    <h3 id="syllabus-r">https://swcarpentry.github.io/r-novice-gapminder-es/</h3>
+    <h3 id="syllabus-r">R para Análisis Científicos Reproducibles</h3>
     <ul>
     	<li>Gestión de proyectos con RStudio</li>
       <li>Explorando Data Frames</li>


### PR DESCRIPTION
This does a few "small" things:
- hides python (since we don't have that translated)
- translates Unix title to "La Terminal de Unix"
- capitalizes Git title to "Control de Versiones con Git"

And one large thing:
- creates a short summary of the "R para Análisis Científicos Reproducibles" lesson. 

The original styles repo doesn't have a summary of "R for Reproducible Scientific Analysis", so I created this one, using the Programming in R summary as a guideline but adding the topics covered in the actual lesson. 